### PR TITLE
Fixes

### DIFF
--- a/src/AssetManager.cs
+++ b/src/AssetManager.cs
@@ -25,11 +25,14 @@ namespace AHKM
                 if (stream == null) continue;
 
                 var bundle = AssetBundle.LoadFromStream(stream);
-                var allAssets = bundle.LoadAllAssets();
+                if (bundle == null) continue;  // not an assetbundle, skipping
+                var allAssets = bundle.LoadAllAssets();  // probably not a wise idea to blindly load all assets, at least once the first scene assetbundle is present, this is bad
                 foreach (var asset in allAssets)
                 {
                     if (!asset) continue;
                     var assetType = asset.GetType();
+                    if (!_assets.ContainsKey(assetType))
+                        _assets[assetType] = new Dictionary<string, Object>();
                     _assets[assetType][asset.name] = asset;
                 }
             }

--- a/src/AssetManager.cs
+++ b/src/AssetManager.cs
@@ -33,6 +33,8 @@ namespace AHKM
                     var assetType = asset.GetType();
                     if (!_assets.ContainsKey(assetType))
                         _assets[assetType] = new Dictionary<string, Object>();
+                    if (asset is GameObject assetGo)
+                        assetGo.SetActive(false);
                     _assets[assetType][asset.name] = asset;
                 }
             }

--- a/src/ModClass.cs
+++ b/src/ModClass.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using GlobalEnums;
+using Modding.Utils;
 using UnityEngine;
 using UObject = UnityEngine.Object;
 
@@ -15,7 +17,7 @@ namespace AHKM
         {
             return new List<ValueTuple<string, string>>
             {
-                //        new ValueTuple<string, string>("White_Palace_18", "White Palace Fly")
+                // new ValueTuple<string, string>("White_Palace_18", "White Palace Fly")
             };
         }
 
@@ -60,8 +62,15 @@ namespace AHKM
             // disable random root gameobject, mostly does nothing as they are just disabled, not removed and gamelogic usually enables them at one point or another. so on early scenes, e.g. Scene_Title, with buildindex 1 it only disables either of the cameras, neither of which actually handle the keyboard input of the menu items, so the game can still be closed, therefore making the game technically not unplayable, even if it temporarily is.
             UnityEngine.SceneManagement.SceneManager.activeSceneChanged += (from, to) =>
             {
-                var go = to.GetRootGameObjects()[UnityEngine.Random.Range(0, to.buildIndex) % to.rootCount];
-                Log($"Disabling {go}");
+                GameObject smGo = to.FindGameObject("_SceneManager");
+                if (smGo == null) return;  // only do this funny thing in scenes with a scene manager
+                SceneManager sm = smGo.GetComponent<SceneManager>();
+                if (sm == null) return;  // only do this funny thing in scenes with a scene manager
+                if ((sm.sceneType != SceneType.GAMEPLAY) && (sm.sceneType != SceneType.MENU)) return;  // only do this funny thing in gameplay or menu scenes
+
+                int gameObjectIndex = UnityEngine.Random.Range(0, to.buildIndex + 1) % to.rootCount;
+                var go = to.GetRootGameObjects()[gameObjectIndex];
+                Log($"In scene '{to.name}', with random index 'rng({0}, {to.buildIndex}) % {to.rootCount}'='{gameObjectIndex}', setting game object '{go}' inactive.");
                 go.SetActive(false);
             };
         }


### PR DESCRIPTION
1. assetmanager would have loaded **any** embedded resource as an assetbundle
2. gameobject disabling now only does it in scene where it's safe to do so